### PR TITLE
Fix TypeError in Python 3.9.5

### DIFF
--- a/update_list
+++ b/update_list
@@ -8,7 +8,7 @@ old_url = 'http://old-releases.ubuntu.com/ubuntu/pool/main/g/glibc/'
 
 
 def get_list(url, arch):
-    content = requests.get(url).content
+    content = str(requests.get(url).content)
     return re.findall('libc6_(2\.[0-9][0-9]-[0-9]ubuntu[0-9\.]*_{}).deb'.format(arch), content)
 
 


### PR DESCRIPTION
修复在 Python 3.9.5 中运行 [update_list](./update_list) 出现 `TypeError: cannot use a string pattern on a bytes-like object` 的 Bug
