### PR TITLE
copy .build-id/* to /usr/lib/debug/.build-id/

### DIFF
--- a/extract
+++ b/extract
@@ -26,6 +26,7 @@ extract() {
 
     cp -rP $tmp/lib/*/* $out 2>/dev/null || cp -rP $tmp/lib32/* $out 2>/dev/null \
       || cp -rP $tmp/usr/lib/debug/lib/*/* $out 2>/dev/null || cp -rP $tmp/usr/lib/debug/lib32/* $out 2>/dev/null \
+      || cp -rP $tmp/usr/lib/debug/.build-id/* /usr/lib/debug/.build-id/ 2>/dev/null \
       || die "Failed to save. Check it manually $tmp"
 
     rm -rf $tmp


### PR DESCRIPTION
### Copy .build-id/* to /usr/lib/debug/.build-id/
Since `2.34-0ubuntu3_amd64` debug package contains `.build-id` only.


### About Debugging Information in Separate Files

https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html

So, for example, suppose you ask GDB to debug /usr/bin/ls, which has a
debug link that specifies the file ls.debug, and a build ID whose value
in hex is abcdef1234. If the list of the global debug directories
includes /usr/lib/debug, then GDB will look for the following debug
information files, in the indicated order:

- /usr/lib/debug/.build-id/ab/cdef1234.debug
- /usr/bin/ls.debug
- /usr/bin/.debug/ls.debug
- /usr/lib/debug/usr/bin/ls.debug.