### PR TITLE
Change command for exctraction .build-id debug files

### DIFF
--- a/extract
+++ b/extract
@@ -28,9 +28,11 @@ extract() {
     fi
     cd -
 
-    cp -rP $tmp/lib/*/* $out 2>/dev/null || cp -rP $tmp/lib32/* $out 2>/dev/null \
-      || cp -rP $tmp/usr/lib/debug/lib/*/* $out 2>/dev/null || cp -rP $tmp/usr/lib/debug/lib32/* $out 2>/dev/null \
-      || cp -rP $tmp/usr/lib/debug/.build-id/* /usr/lib/debug/.build-id/ 2>/dev/null \
+    cp -rP $tmp/lib/*/* $out 2>/dev/null \
+      || cp -rP $tmp/lib32/* $out 2>/dev/null \
+      || cp -rP $tmp/usr/lib/debug/lib/*/* $out 2>/dev/null \
+      || cp -rP $tmp/usr/lib/debug/lib32/* $out 2>/dev/null \
+      || cp -rP $tmp/usr/lib/debug/.build-id $out 2>/dev/null \
       || die "Failed to save. Check it manually $tmp"
 
     rm -rf $tmp


### PR DESCRIPTION
Hi.

Thanks for your tools.
I happy to use it but for 2.34 there was problem with debug file extraction.
I changed command for debug file extraction if debug info consist in separated files.