### PR TITLE
fix: glibc 2.39 extract

### DIFF
--- a/extract
+++ b/extract
@@ -30,6 +30,7 @@ extract() {
 
     cp -rP $tmp/lib/*/* $out 2>/dev/null \
       || cp -rP $tmp/lib32/* $out 2>/dev/null \
+      || cp -rP $tmp/usr/lib/*/* $out 2>/dev/null \
       || cp -rP $tmp/usr/lib/debug/lib/*/* $out 2>/dev/null \
       || cp -rP $tmp/usr/lib/debug/lib32/* $out 2>/dev/null \
       || cp -rP $tmp/usr/lib/debug/.build-id $out 2>/dev/null \


### PR DESCRIPTION
```shell
$ ./download 2.39-0ubuntu8.1_amd64
Getting 2.39-0ubuntu8.1_amd64
  -> Location: https://mirror.tuna.tsinghua.edu.cn/ubuntu/pool/main/g/glibc/libc6_2.39-0ubuntu8.1_amd64.deb
  -> Downloading libc binary package
  -> Extracting libc binary package
x - debian-binary
x - control.tar.zst
x - data.tar.zst
/xxxxxxx/glibc-all-in-one-master
Failed to save. Check it manually /tmp/tmp.OY5Lb8MtBS
```
the file tree of /tmp/tmp.OY5Lb8MtBS is
```shell
/tmp/tmp.OY5Lb8MtBS
├── control.tar.zst
├── data.tar.zst
├── debian-binary
├── etc
│   └── ld.so.conf.d
│       └── x86_64-linux-gnu.conf
└── usr
    ├── lib
    │   └── x86_64-linux-gnu
    │       ├── gconv
    │       │   ├── ANSI_X3.110.so
    │       │   ├── ARMSCII-8.so
    │       │   ├── ASMO_449.so
    │       │   ├── BIG5.so
    │       │   ├── BIG5HKSCS.so
    │       │   ├── BRF.so
    │       │   ├── CP10007.so
    │       │   ├── CP1125.so
    │       │   ├── CP1250.so
    │       │   ├── CP1251.so
    │       │   ├── CP1252.so
    │       │   ├── CP1253.so
    │       │   ├── CP1254.so
    │       │   ├── CP1255.so
    │       │   ├── CP1256.so
    │       │   ├── CP1257.so
    │       │   ├── CP1258.so
    │       │   ├── CP737.so
    │       │   ├── CP770.so
    │       │   ├── CP771.so
    │       │   ├── CP772.so
    │       │   ├── CP773.so
    │       │   ├── CP774.so
    │       │   ├── CP775.so
    │       │   ├── CP932.so
    │       │   ├── CSN_369103.so
    │       │   ├── CWI.so
    │       │   ├── DEC-MCS.so
    │       │   ├── EBCDIC-AT-DE-A.so
    │       │   ├── EBCDIC-AT-DE.so
    │       │   ├── EBCDIC-CA-FR.so
    │       │   ├── EBCDIC-DK-NO-A.so
    │       │   ├── EBCDIC-DK-NO.so
    │       │   ├── EBCDIC-ES-A.so
    │       │   ├── EBCDIC-ES-S.so
    │       │   ├── EBCDIC-ES.so
    │       │   ├── EBCDIC-FI-SE-A.so
    │       │   ├── EBCDIC-FI-SE.so
    │       │   ├── EBCDIC-FR.so
    │       │   ├── EBCDIC-IS-FRISS.so
    │       │   ├── EBCDIC-IT.so
    │       │   ├── EBCDIC-PT.so
    │       │   ├── EBCDIC-UK.so
    │       │   ├── EBCDIC-US.so
    │       │   ├── ECMA-CYRILLIC.so
    │       │   ├── EUC-CN.so
    │       │   ├── EUC-JISX0213.so
    │       │   ├── EUC-JP-MS.so
    │       │   ├── EUC-JP.so
    │       │   ├── EUC-KR.so
    │       │   ├── EUC-TW.so
    │       │   ├── GB18030.so
    │       │   ├── GBBIG5.so
    │       │   ├── GBGBK.so
    │       │   ├── GBK.so
    │       │   ├── GEORGIAN-ACADEMY.so
    │       │   ├── GEORGIAN-PS.so
    │       │   ├── GOST_19768-74.so
    │       │   ├── GREEK-CCITT.so
    │       │   ├── GREEK7-OLD.so
    │       │   ├── GREEK7.so
    │       │   ├── HP-GREEK8.so
    │       │   ├── HP-ROMAN8.so
    │       │   ├── HP-ROMAN9.so
    │       │   ├── HP-THAI8.so
    │       │   ├── HP-TURKISH8.so
    │       │   ├── IBM037.so
    │       │   ├── IBM038.so
    │       │   ├── IBM1004.so
    │       │   ├── IBM1008.so
    │       │   ├── IBM1008_420.so
    │       │   ├── IBM1025.so
    │       │   ├── IBM1026.so
    │       │   ├── IBM1046.so
    │       │   ├── IBM1047.so
    │       │   ├── IBM1097.so
    │       │   ├── IBM1112.so
    │       │   ├── IBM1122.so
    │       │   ├── IBM1123.so
    │       │   ├── IBM1124.so
    │       │   ├── IBM1129.so
    │       │   ├── IBM1130.so
    │       │   ├── IBM1132.so
    │       │   ├── IBM1133.so
    │       │   ├── IBM1137.so
    │       │   ├── IBM1140.so
    │       │   ├── IBM1141.so
    │       │   ├── IBM1142.so
    │       │   ├── IBM1143.so
    │       │   ├── IBM1144.so
    │       │   ├── IBM1145.so
    │       │   ├── IBM1146.so
    │       │   ├── IBM1147.so
    │       │   ├── IBM1148.so
    │       │   ├── IBM1149.so
    │       │   ├── IBM1153.so
    │       │   ├── IBM1154.so
    │       │   ├── IBM1155.so
    │       │   ├── IBM1156.so
    │       │   ├── IBM1157.so
    │       │   ├── IBM1158.so
    │       │   ├── IBM1160.so
    │       │   ├── IBM1161.so
    │       │   ├── IBM1162.so
    │       │   ├── IBM1163.so
    │       │   ├── IBM1164.so
    │       │   ├── IBM1166.so
    │       │   ├── IBM1167.so
    │       │   ├── IBM12712.so
    │       │   ├── IBM1364.so
    │       │   ├── IBM1371.so
    │       │   ├── IBM1388.so
    │       │   ├── IBM1390.so
    │       │   ├── IBM1399.so
    │       │   ├── IBM16804.so
    │       │   ├── IBM256.so
    │       │   ├── IBM273.so
    │       │   ├── IBM274.so
    │       │   ├── IBM275.so
    │       │   ├── IBM277.so
    │       │   ├── IBM278.so
    │       │   ├── IBM280.so
    │       │   ├── IBM281.so
    │       │   ├── IBM284.so
    │       │   ├── IBM285.so
    │       │   ├── IBM290.so
    │       │   ├── IBM297.so
    │       │   ├── IBM420.so
    │       │   ├── IBM423.so
    │       │   ├── IBM424.so
    │       │   ├── IBM437.so
    │       │   ├── IBM4517.so
    │       │   ├── IBM4899.so
    │       │   ├── IBM4909.so
    │       │   ├── IBM4971.so
    │       │   ├── IBM500.so
    │       │   ├── IBM5347.so
    │       │   ├── IBM803.so
    │       │   ├── IBM850.so
    │       │   ├── IBM851.so
    │       │   ├── IBM852.so
    │       │   ├── IBM855.so
    │       │   ├── IBM856.so
    │       │   ├── IBM857.so
    │       │   ├── IBM858.so
    │       │   ├── IBM860.so
    │       │   ├── IBM861.so
    │       │   ├── IBM862.so
    │       │   ├── IBM863.so
    │       │   ├── IBM864.so
    │       │   ├── IBM865.so
    │       │   ├── IBM866.so
    │       │   ├── IBM866NAV.so
    │       │   ├── IBM868.so
    │       │   ├── IBM869.so
    │       │   ├── IBM870.so
    │       │   ├── IBM871.so
    │       │   ├── IBM874.so
    │       │   ├── IBM875.so
    │       │   ├── IBM880.so
    │       │   ├── IBM891.so
    │       │   ├── IBM901.so
    │       │   ├── IBM902.so
    │       │   ├── IBM903.so
    │       │   ├── IBM9030.so
    │       │   ├── IBM904.so
    │       │   ├── IBM905.so
    │       │   ├── IBM9066.so
    │       │   ├── IBM918.so
    │       │   ├── IBM921.so
    │       │   ├── IBM922.so
    │       │   ├── IBM930.so
    │       │   ├── IBM932.so
    │       │   ├── IBM933.so
    │       │   ├── IBM935.so
    │       │   ├── IBM937.so
    │       │   ├── IBM939.so
    │       │   ├── IBM943.so
    │       │   ├── IBM9448.so
    │       │   ├── IEC_P27-1.so
    │       │   ├── INIS-8.so
    │       │   ├── INIS-CYRILLIC.so
    │       │   ├── INIS.so
    │       │   ├── ISIRI-3342.so
    │       │   ├── ISO-2022-CN-EXT.so
    │       │   ├── ISO-2022-CN.so
    │       │   ├── ISO-2022-JP-3.so
    │       │   ├── ISO-2022-JP.so
    │       │   ├── ISO-2022-KR.so
    │       │   ├── ISO-IR-197.so
    │       │   ├── ISO-IR-209.so
    │       │   ├── ISO646.so
    │       │   ├── ISO8859-1.so
    │       │   ├── ISO8859-10.so
    │       │   ├── ISO8859-11.so
    │       │   ├── ISO8859-13.so
    │       │   ├── ISO8859-14.so
    │       │   ├── ISO8859-15.so
    │       │   ├── ISO8859-16.so
    │       │   ├── ISO8859-2.so
    │       │   ├── ISO8859-3.so
    │       │   ├── ISO8859-4.so
    │       │   ├── ISO8859-5.so
    │       │   ├── ISO8859-6.so
    │       │   ├── ISO8859-7.so
    │       │   ├── ISO8859-8.so
    │       │   ├── ISO8859-9.so
    │       │   ├── ISO8859-9E.so
    │       │   ├── ISO_10367-BOX.so
    │       │   ├── ISO_11548-1.so
    │       │   ├── ISO_2033.so
    │       │   ├── ISO_5427-EXT.so
    │       │   ├── ISO_5427.so
    │       │   ├── ISO_5428.so
    │       │   ├── ISO_6937-2.so
    │       │   ├── ISO_6937.so
    │       │   ├── JOHAB.so
    │       │   ├── KOI-8.so
    │       │   ├── KOI8-R.so
    │       │   ├── KOI8-RU.so
    │       │   ├── KOI8-T.so
    │       │   ├── KOI8-U.so
    │       │   ├── LATIN-GREEK-1.so
    │       │   ├── LATIN-GREEK.so
    │       │   ├── MAC-CENTRALEUROPE.so
    │       │   ├── MAC-IS.so
    │       │   ├── MAC-SAMI.so
    │       │   ├── MAC-UK.so
    │       │   ├── MACINTOSH.so
    │       │   ├── MIK.so
    │       │   ├── NATS-DANO.so
    │       │   ├── NATS-SEFI.so
    │       │   ├── PT154.so
    │       │   ├── RK1048.so
    │       │   ├── SAMI-WS2.so
    │       │   ├── SHIFT_JISX0213.so
    │       │   ├── SJIS.so
    │       │   ├── T.61.so
    │       │   ├── TCVN5712-1.so
    │       │   ├── TIS-620.so
    │       │   ├── TSCII.so
    │       │   ├── UHC.so
    │       │   ├── UNICODE.so
    │       │   ├── UTF-16.so
    │       │   ├── UTF-32.so
    │       │   ├── UTF-7.so
    │       │   ├── VISCII.so
    │       │   ├── gconv-modules
    │       │   ├── gconv-modules.cache
    │       │   ├── gconv-modules.d
    │       │   │   └── gconv-modules-extra.conf
    │       │   ├── libCNS.so
    │       │   ├── libGB.so
    │       │   ├── libISOIR165.so
    │       │   ├── libJIS.so
    │       │   ├── libJISX0213.so
    │       │   └── libKSC.so
    │       ├── ld-linux-x86-64.so.2
    │       ├── libBrokenLocale.so.1
    │       ├── libanl.so.1
    │       ├── libc.so.6
    │       ├── libc_malloc_debug.so.0
    │       ├── libdl.so.2
    │       ├── libm.so.6
    │       ├── libmemusage.so
    │       ├── libmvec.so.1
    │       ├── libnsl.so.1
    │       ├── libnss_compat.so.2
    │       ├── libnss_dns.so.2
    │       ├── libnss_files.so.2
    │       ├── libnss_hesiod.so.2
    │       ├── libpcprofile.so
    │       ├── libpthread.so.0
    │       ├── libresolv.so.2
    │       ├── librt.so.1
    │       ├── libthread_db.so.1
    │       └── libutil.so.1
    ├── lib64
    │   └── ld-linux-x86-64.so.2 -> ../lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
    └── share
        ├── doc
        │   └── libc6
        │       ├── NEWS.Debian.gz
        │       ├── NEWS.gz
        │       ├── README.Debian.gz
        │       ├── README.hesiod.gz
        │       ├── changelog.Debian.gz
        │       └── copyright
        └── lintian
            └── overrides
                └── libc6

13 directories, 288 files
```
I modify the `extract` script, add a line, then it work.
```shell
|| cp -rP $tmp/usr/lib/*/* $out 2>/dev/null \
```